### PR TITLE
typo-Update README.md

### DIFF
--- a/evm-verifier/README.md
+++ b/evm-verifier/README.md
@@ -15,7 +15,7 @@ The verifier is composed of multiple contracts as described below.
 3. MerkleStatementContract - Merkle verifier used by the CpuVerifier.
 4. FriStatementContract - Fri verifier used by the CpuVerifier.
 5. MemoryPageFactRegistry - Fact registry for memory claims used by the CpuVerifier.
-6. Auxilliary contracts used by the above verifiers to calculate polynomial evaluations:
+6. Auxiliary contracts used by the above verifiers to calculate polynomial evaluations:
    1. CpuConstraintPoly
    2. EcdsaPointsXColumn
    3. EcdsaPointsYColumn


### PR DESCRIPTION
# Fix: Corrected typo in README file

## Changes
1. **File**: `evm-verifier/README.md`
   - Fixed a typo by changing "Auxilliary" to "Auxiliary".

## Purpose
- Improved documentation accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the README file.
